### PR TITLE
ci: Remove special-casing for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,8 @@ jobs:
         uses: actions/checkout@v1
 
       - uses: actions/setup-python@v2
-        if: matrix.python-version != 3.9
         with:
           python-version: ${{ matrix.python-version }}
-
-      - uses: actions/setup-python@v2
-        if: matrix.python-version == 3.9
-        with:
-          python-version: '3.9.0-alpha - 3.9.0'
 
       - name: Install dependencies
         run: |
@@ -86,14 +80,8 @@ jobs:
       - uses: actions/checkout@v1
 
       - uses: actions/setup-python@v2
-        if: matrix.python-version != 3.9
         with:
           python-version: ${{ matrix.python-version }}
-
-      - uses: actions/setup-python@v2
-        if: matrix.python-version == 3.9
-        with:
-          python-version: '3.9.0-alpha - 3.9.0'
 
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
It's a regular release nowadays.