### PR TITLE
ci: Run on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   release:
     types: [created]
   push:
+  pull_request:
   schedule:
     # Runs every Thursday at 20:23 GMT to avoid bit rot
     - cron: "20 23 * * 4"


### PR DESCRIPTION
Right now the CI is configured to only run on pushes (to this repository), but not on PRs (from another repository).

The downside of this is that PRs for a branch in this repository will run twice. If you only push directly to e.g. master, it might be worth adjusting that - also see https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662