### PR TITLE
Add aliases argument to `Engine.add_resource`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ## Unreleased
 ---
+### Added
+* Added `aliases` optional argument to `Engine.add_resource`
+
 ### Changes
 * Update PyO3 dependency to `0.16`.
 * Update upstream dependency to `0.5.6`.

--- a/adblock/adblock.pyi
+++ b/adblock/adblock.pyi
@@ -117,7 +117,13 @@ class Engine:
         pass
     def tag_exists(self, tag: str) -> bool:
         pass
-    def add_resource(self, name: str, content_type: str, content: str) -> bool:
+    def add_resource(
+        self,
+        name: str,
+        content_type: str,
+        content: str,
+        aliases: Optional[List[str]] = None,
+    ) -> bool:
         pass
     def url_cosmetic_resources(self, url: str) -> UrlSpecificResources:
         pass

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,16 +530,27 @@ impl Engine {
     ///
     /// # Arguments
     /// * `name`: Represents the primary name of the resource, often a filename
-    /// * `content_type`: How to interpret the resource data within `content`
+    /// * `content_type`: How to interpret the resource data within `content`.
+    ///   Use `"template"` if wanting to specify a template resource type.
     /// * `content`: The resource data, encoded using standard base64 configuration
-    #[pyo3(text_signature = "($self, name, content_type, content)")]
-    pub fn add_resource(&mut self, name: &str, content_type: &str, content: &str) -> PyResult<()> {
+    /// * `aliases`: List of aliases for the resource
+    #[pyo3(text_signature = "($self, name, content_type, content, aliases)")]
+    pub fn add_resource(
+        &mut self,
+        name: &str,
+        content_type: &str,
+        content: &str,
+        aliases: Option<Vec<String>>,
+    ) -> PyResult<()> {
         let result = self.engine.add_resource(Resource {
             name: name.to_string(),
-            aliases: vec![],
-            kind: ResourceType::Mime(MimeType::from(std::borrow::Cow::from(
-                content_type.to_string(),
-            ))),
+            aliases: aliases.unwrap_or_default(),
+            kind: match content_type {
+                "template" => ResourceType::Template,
+                _ => ResourceType::Mime(MimeType::from(std::borrow::Cow::from(
+                    content_type.to_string(),
+                ))),
+            },
             content: content.to_string(),
         });
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -30,6 +30,9 @@ def test_add_resource_error():
         # }
         # xOO6ww== => base64.b64encode('你好'.encode('gbk'))
         engine.add_resource(
-            name="aa", content_type="application/javascript", content="xOO6ww=="
+            name="aa",
+            content_type="application/javascript",
+            content="xOO6ww==",
+            aliases=[],
         )
     assert "invalid utf content" in str(exc.value)


### PR DESCRIPTION
This is a variation of https://github.com/ArniDagur/python-adblock/pull/70 except this version uses an optional argument at the last position, rather than a required argument in the second position.