### PR TITLE
PEP 621 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,31 +148,31 @@ jobs:
           [
             {
               toolchain: "1.53",
-              manylinux: "2010",
+              manylinux: "2014",
               target: "x86_64-unknown-linux-gnu",
               arch: "x86_64",
               python-version: "3.7"
             },
             {
               toolchain: "nightly",
-              manylinux: "2010",
+              manylinux: "2014",
               target: "x86_64-unknown-linux-gnu",
               arch: "x86_64",
               python-version: "3.7"
             },
             {
               toolchain: "stable",
-              manylinux: "2010",
+              manylinux: "2014",
               target: "x86_64-unknown-linux-gnu",
               arch: "x86_64",
               python-version: "3.7"
             },
             {
               toolchain: "stable",
-              manylinux: "2010",
+              manylinux: "2014",
               target: "x86_64-unknown-linux-gnu",
               arch: "x86_64",
-              python-version: "3.10"
+              python-version: "3.11"
             }
           ]
     steps:
@@ -184,7 +184,7 @@ jobs:
 
       - name: Build Wheels
         run: |
-          echo 'curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ matrix.platform.toolchain }}
+          echo 'curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ matrix.platform.toolchain }}
           source ~/.cargo/env
           export PATH=/opt/python/cp38-cp38/bin:$PATH
           pip install maturin
@@ -245,6 +245,7 @@ jobs:
           echo 'curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
           source ~/.cargo/env
           rustup target add ${{ matrix.platform.target }}
+          pip install maturin
           maturin build -i python --release --out dist --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }}
           ' > build-wheel.sh
           chmod +x build-wheel.sh
@@ -296,6 +297,7 @@ jobs:
 
       - name: Wheel filename sanity checks
         run: |
+          ls -lah
           num_abi3_whl=$(find | grep "\./adblock.*-abi3.*\.whl" | wc -l)
           num_whl=$(find | grep "\./adblock.*\.whl" | wc -l)
           test $num_abi3_whl -eq $num_whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,6 @@ jobs:
           num_whl=$(find | grep "\./adblock.*\.whl" | wc -l)
           test $num_abi3_whl -eq $num_whl
           test $num_whl -ge 1
-          find | grep "\./adblock-.*\.tar\.gz"
 
       - name: PyPi publish
         if: github.event_name == 'release' && github.event.action == 'created'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,6 @@ readme = "README.md"
 homepage = "https://github.com/ArniDagur/python-adblock"
 repository = "https://github.com/ArniDagur/python-adblock"
 
-[package.metadata.maturin]
-classifier = [
-    "Programming Language :: Python",
-    "Programming Language :: Rust",
-    "License :: OSI Approved :: MIT License",
-    "License :: OSI Approved :: Apache Software License",
-]
-requires-python = ">=3.7"
-
 [profile.release]
 debug = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,18 @@
-[tool.poetry]
+[project]
 name = "adblock"
 version = "0.0.0"
 description = "Brave's adblocking in Python"
-authors = ["Árni Dagur <arni@dagur.eu>"]
+requires-python = ">=3.7"
+authors = [
+    {email = "arni@dagur.eu"},
+    {name = "Árni Dagur"}
+]
+classifiers = [
+    "Programming Language :: Python",
+    "Programming Language :: Rust",
+    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
+]
 
 [tool.poetry.dependencies]
 python = "^3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,21 @@
 [project]
 name = "adblock"
-version = "0.0.0"
+version = "0.6.0"
 description = "Brave's adblocking in Python"
 requires-python = ">=3.7"
-authors = [
-    {email = "arni@dagur.eu"},
-    {name = "Árni Dagur"}
-]
+authors = [{ name = "Árni Dagur", email = "arni@dagur.eu" }]
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Rust",
     "License :: OSI Approved :: MIT License",
     "License :: OSI Approved :: Apache Software License",
 ]
+
+[tool.poetry]
+name = "adblock"
+version = "0.6.0"
+description = "Brave's adblocking in Python"
+authors = ["Árni Dagur <arni@dagur.eu>"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
@@ -23,5 +26,5 @@ pytest = "*"
 toml = "*"
 
 [build-system]
-requires = ["maturin>=0.12,<0.13"]
+requires = ["maturin>=0.12"]
 build-backend = "maturin"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -57,10 +57,10 @@ def test_required_python_version():
     Make sure that the Python interpreter we're running this test suite on
     falls into the required Python range.
     """
-    with open("Cargo.toml", encoding="utf-8") as f:
-        cargo_toml = toml.loads(f.read())
+    with open("pyproject.toml", encoding="utf-8") as f:
+        pyproject_toml = toml.loads(f.read())
 
-    required_python = cargo_toml["package"]["metadata"]["maturin"]["requires-python"]
+    required_python = pyproject_toml["project"]["requires-python"]
     assert required_python.startswith(">=")
     required_python = required_python[2:]
     assert get_current_python_version() >= parse_version(required_python)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -16,6 +16,15 @@ def get_version_value_cargo():
     return parse_version(cargo_toml["package"]["version"])
 
 
+def get_version_values_pyproject():
+    with open("pyproject.toml", encoding="utf-8") as f:
+        pyproject_toml = toml.loads(f.read())
+    return [
+        parse_version(pyproject_toml["project"]["version"]),
+        parse_version(pyproject_toml["tool"]["poetry"]["version"]),
+    ]
+
+
 def get_version_value_changelog():
     """
     Try to get the names of all classes that we added to the Python module
@@ -37,15 +46,18 @@ def get_version_value_changelog():
 
 def test_version_numbers_all_same():
     """
-    Makes sure that `Cargo.toml` and `CHANGELOG.md` contain the same version
-    number as the one attached to the `adblock` module.
+    Makes sure that `pyproject.toml`, `Cargo.toml` and `CHANGELOG.md` contain
+    the same version number as the one attached to the `adblock` module.
     """
     cargo_version = get_version_value_cargo()
     changelog_version = get_version_value_changelog()
+    pyproject_versions = get_version_values_pyproject()
     module_version = parse_version(adblock.__version__)
 
     assert cargo_version == module_version
     assert module_version == changelog_version
+    assert changelog_version == pyproject_versions[0]
+    assert pyproject_versions[0] == pyproject_versions[1]
 
 
 def get_current_python_version():


### PR DESCRIPTION
Since https://github.com/PyO3/maturin/pull/1471 the build fails with
```
💥 maturin failed
  Caused by: The following metadata fields in `package.metadata.maturin` section of Cargo.toml are removed since maturin 0.14.0: classifier, requires-python, please set them in pyproject.toml as PEP 621 specifies.
```