### PR TITLE
update configuration for poetry 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,13 @@ classifiers = [
 ]
 
 [tool.poetry]
+requires-poetry = ">=2.0"
 name = "adblock"
 version = "0.6.0"
 description = "Brave's adblocking in Python"
 authors = ["Árni Dagur <arni@dagur.eu>"]
 
-[tool.poetry.dependencies]
-python = "^3.6"
-
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 maturin = "*"
 pytest = "*"
 toml = "*"


### PR DESCRIPTION
The poetry docs suggest using `project.dependencies` in favour of `tool.poetry.dependencies`.
See also <https://python-poetry.org/docs/dependency-specification/>.

For the dev dependencies there was a deprecation warning because the used version of specifying dev dependencies has been deprecated in poetry 2.0.0.
See also <https://python-poetry.org/blog/announcing-poetry-2.0.0/>.